### PR TITLE
bugfix OpenGL performance hog

### DIFF
--- a/libs/openFrameworks/gl/ofShader.h
+++ b/libs/openFrameworks/gl/ofShader.h
@@ -127,7 +127,7 @@ public:
 
 	// these are used only for openGL ES2 or GL3/4 using the programmable GL renderer
 	enum defaultAttributes{
-		POSITION_ATTRIBUTE=1,
+		POSITION_ATTRIBUTE=0,  // tig: was =1, and BOY, what a performance hog this was!!! see: http://www.chromium.org/nativeclient/how-tos/3d-tips-and-best-practices
 		COLOR_ATTRIBUTE,
 		NORMAL_ATTRIBUTE,
 		TEXCOORD_ATTRIBUTE


### PR DESCRIPTION
ofShader is rolling its own manual location table for attributes.

The position attribute, which is the first attribute, was set to 1, leaving attribute 0 unset. This did lead to catastrophic performance losses on certain graphics cards (ATI, OS X).

See also: "In OpenGL you MUST enable Attrib 0"

in: http://www.chromium.org/nativeclient/how-tos/3d-tips-and-best-practices
Signed-off-by: tgfrerer tim@poniesandlight.co.uk
