### PR TITLE
fix glfwWindow for os x

### DIFF
--- a/libs/openFrameworks/app/ofAppGLFWWindow.cpp
+++ b/libs/openFrameworks/app/ofAppGLFWWindow.cpp
@@ -10,6 +10,7 @@
 #define GLFW_EXPOSE_NATIVE_GLX
 #include "GL/glfw3native.h"
 #elif defined(TARGET_OSX)
+#include <Cocoa/Cocoa.h>
 #define GLFW_EXPOSE_NATIVE_COCOA
 #define GLFW_EXPOSE_NATIVE_NSGL
 #include "GL/glfw3native.h"
@@ -459,8 +460,8 @@ void ofAppGLFWWindow::setFullscreen(bool fullscreen){
         setWindowShape(nonFullScreenW,nonFullScreenH);
         setWindowPosition(nonFullScreenX,nonFullScreenY);
 		//----------------------------------------------------
-#endif
 	}
+#endif
 }
 
 //------------------------------------------------------------

--- a/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj/project.pbxproj
+++ b/libs/openFrameworksCompiled/project/osx/openFrameworksLib.xcodeproj/project.pbxproj
@@ -160,7 +160,7 @@
 		2276958F170D9DD200604FC3 /* ofMatrixStack.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofMatrixStack.cpp; sourceTree = "<group>"; };
 		22769590170D9DD200604FC3 /* ofMatrixStack.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofMatrixStack.h; sourceTree = "<group>"; };
 		22A1C452170AFCB60079E473 /* ofRendererCollection.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofRendererCollection.cpp; sourceTree = "<group>"; };
-		22FAD01C17049373002A7EB3 /* ofAppGLFWWindow.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ofAppGLFWWindow.cpp; sourceTree = "<group>"; };
+		22FAD01C17049373002A7EB3 /* ofAppGLFWWindow.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = ofAppGLFWWindow.cpp; sourceTree = "<group>"; };
 		22FAD01D17049373002A7EB3 /* ofAppGLFWWindow.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ofAppGLFWWindow.h; sourceTree = "<group>"; };
 		2E6EA7001603A9E400B7ADF3 /* of3dGraphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = of3dGraphics.h; sourceTree = "<group>"; };
 		2E6EA7031603AA7A00B7ADF3 /* of3dGraphics.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = of3dGraphics.cpp; sourceTree = "<group>"; };


### PR DESCRIPTION
- include Cocoa headers if OS X
- switch filetype in XCode to 'Objective-CPP'
- fix hanging curly bracket related to os x  #ifdef

Signed-off-by: tgfrerer tim@poniesandlight.co.uk
