### PR TITLE
fixes a regression issue related to ofNode orbit

### DIFF
--- a/libs/openFrameworks/3d/ofNode.cpp
+++ b/libs/openFrameworks/3d/ofNode.cpp
@@ -483,7 +483,7 @@ void ofNode::orbit(float longitude, float latitude, float radius, const glm::vec
 	p = q * p;							   // rotate p on unit sphere based on quaternion
 	p = p * radius;						   // scale p by radius from its position on unit sphere
 
-	setPosition(centerPoint + p);
+	setGlobalPosition(centerPoint + p);
 	setOrientation(q);
 
 	onOrientationChanged();


### PR DESCRIPTION
as orbit is defined as orbiting around a fixed absolute point in space, the new position of a node should be set as a global position. 

This way, orbiting around another node (when providing a target node for orbiting) will also make sure to orbit around the other node's position.