### PR TITLE
ofOpenALSoundPlayer: fix conflicting forward declaration in newer versions

### DIFF
--- a/libs/openFrameworks/utils/ofJson.h
+++ b/libs/openFrameworks/utils/ofJson.h
@@ -36,10 +36,10 @@ inline bool ofSaveJson(const std::filesystem::path& filename, const ofJson & jso
 	try{
 		jsonFile << json;
 	}catch(std::exception & e){
-		ofLogError("ofLoadJson") << "Error saving json to " << filename.string() << ": " << e.what();
+		ofLogError("ofSaveJson") << "Error saving json to " << filename.string() << ": " << e.what();
 		return false;
 	}catch(...){
-		ofLogError("ofLoadJson") << "Error saving json to " << filename.string();
+		ofLogError("ofSaveJson") << "Error saving json to " << filename.string();
 		return false;
 	}
 	return true;
@@ -54,10 +54,10 @@ inline bool ofSavePrettyJson(const std::filesystem::path& filename, const ofJson
     try{
         jsonFile << json.dump(4);
     }catch(std::exception & e){
-        ofLogError("ofLoadJson") << "Error saving json to " << filename.string() << ": " << e.what();
+        ofLogError("ofSavePrettyJson") << "Error saving json to " << filename.string() << ": " << e.what();
         return false;
     }catch(...){
-        ofLogError("ofLoadJson") << "Error saving json to " << filename.string();
+        ofLogError("ofSavePrettyJson") << "Error saving json to " << filename.string();
         return false;
     }
     return true;


### PR DESCRIPTION
Declare statics inside cpp to avoid forward declaration
